### PR TITLE
Fix RNG shuffle bug and stabilize engine tests

### DIFF
--- a/packages/engine/src/rng.ts
+++ b/packages/engine/src/rng.ts
@@ -1,0 +1,59 @@
+export interface RngState {
+  seed: number;
+  calls: number;
+}
+
+const UINT32_MAX = 0xffffffff;
+
+const toSeed = (seed: string | number): number => {
+  if (typeof seed === 'number') {
+    return seed >>> 0;
+  }
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+};
+
+const next = (state: RngState): number => {
+  const x = state.seed + state.calls * 0x6d2b79f5;
+  const t = Math.imul(x ^ (x >>> 15), 1 | x);
+  const r = ((t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t) >>> 0;
+  state.calls += 1;
+  return r / (UINT32_MAX + 1);
+};
+
+export interface Rng {
+  state: RngState;
+  next: () => number;
+  shuffle: <T>(values: T[]) => T[];
+}
+
+export const createRng = (seed: string | number): Rng => {
+  const state: RngState = { seed: toSeed(seed), calls: 0 };
+  return {
+    state,
+    next: () => next(state),
+    shuffle: <T>(values: T[]) => {
+      const arr = values.slice();
+      for (let i = arr.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(next(state) * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    }
+  };
+};
+
+export const cloneRngState = (state: RngState): RngState => ({
+  seed: state.seed,
+  calls: state.calls
+});
+
+export const restoreRng = (saved: RngState): Rng => {
+  const rng = createRng(saved.seed);
+  rng.state.calls = saved.calls;
+  return rng;
+};

--- a/packages/engine/src/state.ts
+++ b/packages/engine/src/state.ts
@@ -1,0 +1,195 @@
+import { buildDeck, DeckData, resetDeckCounter } from './deck';
+import { createRng, RngState, cloneRngState, restoreRng } from './rng';
+import {
+  Card,
+  Color,
+  GameStatus,
+  PendingDrawState,
+  PendingUnoState,
+  PlayerID,
+  RuleSet
+} from './types';
+import { getFace } from './card';
+
+export interface PlayerState {
+  id: PlayerID;
+  name: string;
+  hand: string[];
+  connected: boolean;
+  unoDeclared: boolean;
+}
+
+export interface GameState {
+  status: GameStatus;
+  ruleSet: RuleSet;
+  players: PlayerState[];
+  spectators: PlayerID[];
+  drawPile: string[];
+  discardPile: string[];
+  cards: Record<string, Card>;
+  activeSide: 'light' | 'dark';
+  currentColor: Color | null;
+  currentPlayerIndex: number;
+  direction: 1 | -1;
+  pendingDraw: PendingDrawState | null;
+  pendingUno: PendingUnoState[];
+  rng: RngState;
+  turn: number;
+  winnerIds: PlayerID[];
+  jumpQueue: PlayerID[];
+  startingHandSize: number;
+  seed: string | number;
+  history: string[];
+}
+
+export interface CreateGameOptions {
+  players: Array<{ id: PlayerID; name: string }>;
+  ruleSet: RuleSet;
+  seed: string | number;
+  startingHandSize?: number;
+}
+
+const drawCardFromPile = (drawPile: string[]): string => {
+  const card = drawPile.pop();
+  if (!card) {
+    throw new Error('Draw pile exhausted');
+  }
+  return card;
+};
+
+const ensureStarterCard = (
+  deck: DeckData,
+  drawPile: string[],
+  side: 'light' | 'dark'
+): string => {
+  while (drawPile.length > 0) {
+    const candidate = drawPile.pop()!;
+    const face = getFace(deck.cards[candidate], side);
+    if (face.kind === 'wild' && face.action !== 'wild') {
+      // Put it back to bottom and continue
+      drawPile.unshift(candidate);
+      continue;
+    }
+    return candidate;
+  }
+  throw new Error('Unable to find starter card');
+};
+
+export const createGameState = ({
+  players,
+  ruleSet,
+  seed,
+  startingHandSize = 7
+}: CreateGameOptions): GameState => {
+  if (players.length < 2 || players.length > 8) {
+    throw new Error('Game requires between 2 and 8 players');
+  }
+  resetDeckCounter();
+  const rng = createRng(seed);
+  const deck = buildDeck(ruleSet, rng);
+  if (deck.drawPile.length === 0) {
+    throw new Error('Empty deck for variant ' + ruleSet.variant);
+  }
+  const drawPile = deck.drawPile.slice();
+  const playerStates: PlayerState[] = players.map((player) => ({
+    id: player.id,
+    name: player.name,
+    hand: [],
+    connected: true,
+    unoDeclared: false
+  }));
+
+  for (let cardIndex = 0; cardIndex < startingHandSize; cardIndex += 1) {
+    playerStates.forEach((player, idx) => {
+      player.hand.push(drawCardFromPile(drawPile));
+    });
+  }
+
+  const activeSide: 'light' | 'dark' = 'light';
+  const starterCard = ensureStarterCard(deck, drawPile, activeSide);
+  const discardPile = [starterCard];
+  const starterFace = getFace(deck.cards[starterCard], activeSide);
+  const currentColor = starterFace.kind === 'wild' ? null : starterFace.color;
+
+  return {
+    status: 'inProgress',
+    ruleSet,
+    players: playerStates,
+    spectators: [],
+    drawPile,
+    discardPile,
+    cards: deck.cards,
+    activeSide,
+    currentColor,
+    currentPlayerIndex: 0,
+    direction: 1,
+    pendingDraw: null,
+    pendingUno: [],
+    rng: cloneRngState(rng.state),
+    turn: 0,
+    winnerIds: [],
+    jumpQueue: [],
+    startingHandSize,
+    seed,
+    history: []
+  };
+};
+
+export const getCurrentPlayer = (state: GameState) => state.players[state.currentPlayerIndex];
+
+export const cloneState = (state: GameState): GameState =>
+  JSON.parse(JSON.stringify(state)) as GameState;
+
+export const reorderPlayers = (state: GameState, newOrder: PlayerID[]): GameState => {
+  const playerMap = new Map(state.players.map((player) => [player.id, player] as const));
+  const ordered = newOrder.map((id) => {
+    const player = playerMap.get(id);
+    if (!player) throw new Error('Unknown player');
+    return { ...player, hand: player.hand.slice() };
+  });
+  return {
+    ...state,
+    players: ordered
+  };
+};
+
+export const nextPlayerIndex = (state: GameState, steps = 1): number => {
+  const count = state.players.length;
+  let idx = state.currentPlayerIndex;
+  for (let i = 0; i < steps; i += 1) {
+    idx = (idx + state.direction + count) % count;
+  }
+  return idx;
+};
+
+export const advanceTurn = (state: GameState, steps = 1): GameState => ({
+  ...state,
+  currentPlayerIndex: nextPlayerIndex(state, steps),
+  turn: state.turn + 1
+});
+
+export const drawCards = (state: GameState, playerId: PlayerID, count: number): { state: GameState; cards: string[] } => {
+  if (count <= 0) return { state, cards: [] };
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) throw new Error('Player not found');
+  const newState = cloneState(state);
+  const target = newState.players.find((p) => p.id === playerId)!;
+  const drawn: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    if (newState.drawPile.length === 0) {
+      const rng = restoreRng(newState.rng);
+      const topDiscard = newState.discardPile[newState.discardPile.length - 1];
+      const rest = newState.discardPile.slice(0, -1);
+      newState.drawPile = rng.shuffle(rest);
+      newState.discardPile = topDiscard ? [topDiscard] : [];
+      newState.rng = cloneRngState(rng.state);
+    }
+    const card = drawCardFromPile(newState.drawPile);
+    drawn.push(card);
+    target.hand.push(card);
+    target.unoDeclared = false;
+  }
+  return { state: newState, cards: drawn };
+};
+
+export const hasWon = (player: PlayerState): boolean => player.hand.length === 0;

--- a/packages/engine/test/engine.spec.ts
+++ b/packages/engine/test/engine.spec.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createGameState,
+  playCard,
+  drawFromDeck,
+  attemptJumpIn,
+  catchUno,
+  RuleSet,
+  getPlayableCards,
+  applyFlip
+} from '../src';
+import { getFace } from '../src';
+
+const baseRules: RuleSet = {
+  stacking: 'anyDrawStacks',
+  forcePlay: false,
+  drawToPlay: 'oneThenPass',
+  jumpIn: { enabled: true, allowOnWildResolution: false },
+  sevenZero: true,
+  unoCall: { required: true, auto: false, penaltyDraw: 2 },
+  variant: 'base'
+};
+
+const createState = (overrides: Partial<RuleSet> = {}) =>
+  createGameState({
+    players: [
+      { id: 'A', name: 'Alice' },
+      { id: 'B', name: 'Bob' },
+      { id: 'C', name: 'Cara' }
+    ],
+    ruleSet: { ...baseRules, ...overrides },
+    seed: 'test-seed'
+  });
+
+const findCard = (state: ReturnType<typeof createState>, predicate: (face: ReturnType<typeof getFace>) => boolean, exclude: string[] = []) => {
+  for (const id of Object.keys(state.cards)) {
+    if (exclude.includes(id)) continue;
+    const face = getFace(state.cards[id], state.activeSide);
+    if (predicate(face)) {
+      return id;
+    }
+  }
+  throw new Error('Card not found');
+};
+
+const removeCard = (state: ReturnType<typeof createState>, cardId: string) => {
+  state.drawPile = state.drawPile.filter((id) => id !== cardId);
+  state.discardPile = state.discardPile.filter((id) => id !== cardId);
+  state.players.forEach((player) => {
+    player.hand = player.hand.filter((id) => id !== cardId);
+  });
+};
+
+describe('engine rules', () => {
+  it('matches cards by color or value', () => {
+    const state = createState();
+    const redFive = findCard(state, (face) => face.kind === 'number' && face.color === 'red' && face.value === 5);
+    const blueFive = findCard(state, (face) => face.kind === 'number' && face.color === 'blue' && face.value === 5);
+    const redSkip = findCard(state, (face) => face.kind === 'action' && face.color === 'red' && face.action === 'skip');
+
+    removeCard(state, redFive);
+    removeCard(state, blueFive);
+    removeCard(state, redSkip);
+
+    state.discardPile = [redFive];
+    state.players[0].hand = [blueFive, redSkip];
+
+    const playable = getPlayableCards(state, state.players[0]);
+    expect(playable).toContain(blueFive);
+    expect(playable).toContain(redSkip);
+  });
+
+  it('supports draw stacking accumulation', () => {
+    const state = createState();
+    const drawTwoA = findCard(state, (face) => face.kind === 'action' && face.action === 'drawTwo');
+    const drawTwoB = findCard(state, (face) => face.kind === 'action' && face.action === 'drawTwo', [drawTwoA]);
+    const fillerCard = findCard(state, (face) => face.kind === 'number', [drawTwoA, drawTwoB]);
+
+    removeCard(state, drawTwoA);
+    removeCard(state, drawTwoB);
+    removeCard(state, fillerCard);
+    state.discardPile = [drawTwoA];
+    state.pendingDraw = {
+      count: 2,
+      sources: [drawTwoA],
+      type: 'drawTwo',
+      target: 'A'
+    };
+    state.currentPlayerIndex = state.players.findIndex((p) => p.id === 'A');
+    state.players[0].hand = [drawTwoB, fillerCard];
+
+    const next = playCard(state, 'A', drawTwoB);
+    expect(next.pendingDraw).not.toBeNull();
+    expect(next.pendingDraw?.count).toBe(4);
+    expect(next.pendingDraw?.sources).toEqual([drawTwoA, drawTwoB]);
+    expect(next.pendingDraw?.target).toBe('B');
+  });
+
+  it('handles jump-in interrupt', () => {
+    const state = createState();
+    const sharedCard = findCard(state, (face) => face.kind === 'number' && face.value === 3 && face.color === 'green');
+    const duplicate = findCard(state, (face) => face.kind === 'number' && face.value === 3 && face.color === 'green', [sharedCard]);
+    removeCard(state, sharedCard);
+    removeCard(state, duplicate);
+    state.discardPile = [sharedCard];
+    state.players[1].hand = [duplicate];
+    const after = attemptJumpIn(state, 'B', duplicate);
+    expect(after.discardPile[after.discardPile.length - 1]).toBe(duplicate);
+    expect(after.players[1].hand).toHaveLength(0);
+  });
+
+  it('applies seven hand swap', () => {
+    const state = createState();
+    const seven = findCard(state, (face) => face.kind === 'number' && face.value === 7);
+    removeCard(state, seven);
+    const filler = findCard(state, (face) => face.kind === 'number', [seven]);
+    removeCard(state, filler);
+    const alt = findCard(state, (face) => face.kind === 'number', [seven, filler]);
+    removeCard(state, alt);
+    state.players[0].hand = [seven];
+    state.players[1].hand = [alt];
+    state.discardPile = [filler];
+    const after = playCard(state, 'A', seven, { targetId: 'B' });
+    expect(after.players[0].hand).toEqual([alt]);
+    expect(after.players[1].hand).toEqual([]);
+  });
+
+  it('rotates hands on zero', () => {
+    const state = createState();
+    const zero = findCard(state, (face) => face.kind === 'number' && face.value === 0);
+    removeCard(state, zero);
+    const filler = findCard(state, (face) => face.kind === 'number' && face.value !== 0, [zero]);
+    removeCard(state, filler);
+    const bCard = findCard(state, (face) => face.kind === 'number', [zero, filler]);
+    const cCard = findCard(state, (face) => face.kind === 'number', [zero, filler, bCard]);
+    removeCard(state, bCard);
+    removeCard(state, cCard);
+    state.discardPile = [filler];
+    state.players[0].hand = [zero];
+    state.players[1].hand = [bCard];
+    state.players[2].hand = [cCard];
+    const after = playCard(state, 'A', zero);
+    expect(after.players[0].hand).toEqual([cCard]);
+    expect(after.players[1].hand).toEqual([]);
+    expect(after.players[2].hand).toEqual([bCard]);
+  });
+
+  it('tracks UNO declaration and penalties', () => {
+    const state = createState();
+    const top = findCard(state, (face) => face.kind === 'number' && face.value !== 9);
+    removeCard(state, top);
+    const topFace = getFace(state.cards[top], state.activeSide);
+    const card = findCard(
+      state,
+      (face) => face.kind === 'number' && face.color === topFace.color && face.value !== topFace.value,
+      [top]
+    );
+    const keeper = findCard(
+      state,
+      (face) => face.kind === 'number' && face.color === topFace.color && face.value !== topFace.value,
+      [top, card]
+    );
+    removeCard(state, card);
+    removeCard(state, keeper);
+    state.discardPile = [top];
+    state.players[0].hand = [card, keeper];
+    state.currentColor = topFace.color;
+    let next = playCard(state, 'A', card, { declareUno: false });
+    expect(next.pendingUno.find((entry) => entry.playerId === 'A')).toBeTruthy();
+    next = catchUno(next, 'B', 'A').state;
+    expect(next.players.find((p) => p.id === 'A')?.hand.length).toBeGreaterThan(0);
+  });
+
+  it('drawn cards remain with player until they play (draw to play)', () => {
+    const state = createState({ drawToPlay: 'untilPlayable' });
+    const card = findCard(state, (face) => face.kind === 'number');
+    removeCard(state, card);
+    state.players[0].hand = [];
+    const result = drawFromDeck(state, 'A', 1);
+    const after = result.state;
+    expect(after.players[0].hand.length).toBe(1);
+    expect(after.currentPlayerIndex).toBe(state.currentPlayerIndex);
+  });
+
+  it('flip keeps deck integrity', () => {
+    const state = createState({ variant: 'unoFlip' });
+    const beforeCount = state.drawPile.length + state.discardPile.length;
+    const flipped = applyFlip(state);
+    const afterCount = flipped.drawPile.length + flipped.discardPile.length;
+    expect(afterCount).toBe(beforeCount);
+    expect(flipped.activeSide).toBe('dark');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize the PRNG output to prevent negative shuffle indices and draw pile underflows
- remove temporary deck debugging from game state creation now that shuffling is stable
- harden engine rule tests to reflect stacking, seven-zero swaps, and UNO penalty behaviour

## Testing
- pnpm -F @game/engine test

------
https://chatgpt.com/codex/tasks/task_e_68df3e1cdb948328b467ba6dca739568